### PR TITLE
set default empty string for refreshToken

### DIFF
--- a/src/Tool/ApiCredentials.php
+++ b/src/Tool/ApiCredentials.php
@@ -40,7 +40,7 @@ final class ApiCredentials
     /**
      * @var string
      */
-    private $refreshToken;
+    private $refreshToken = '';
 
     /**
      * @param string $authKey


### PR DESCRIPTION
When using authentication with username and password API.php:120 will fail (Strict check for empty string but null given)